### PR TITLE
fix: 修復標題顏色，將所有標題顏色改為橘色

### DIFF
--- a/todo_app/lib/screens/add_todo_screen.dart
+++ b/todo_app/lib/screens/add_todo_screen.dart
@@ -57,7 +57,10 @@ class _AddTodoScreenState extends State<AddTodoScreen> {
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(isEditing ? '編輯待辦事項' : '新增待辦事項'),
+        title: Text(
+          isEditing ? '編輯待辦事項' : '新增待辦事項',
+          style: const TextStyle(color: Colors.orange),
+        ),
         actions: [
           if (isEditing)
             IconButton(

--- a/todo_app/lib/screens/home_screen.dart
+++ b/todo_app/lib/screens/home_screen.dart
@@ -35,7 +35,7 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
       appBar: AppBar(
         title: const Text(
           'Todo App',
-          style: TextStyle(color: Colors.blue),
+          style: TextStyle(color: Colors.orange),
         ),
         bottom: PreferredSize(
           preferredSize: const Size.fromHeight(120),
@@ -122,7 +122,7 @@ class _HomeScreenState extends State<HomeScreen> with SingleTickerProviderStateM
                     Text(
                       'Todo App',
                       style: Theme.of(context).textTheme.headlineSmall?.copyWith(
-                        color: Theme.of(context).colorScheme.onPrimary,
+                        color: Colors.orange,
                       ),
                     ),
                     const SizedBox(height: 8),


### PR DESCRIPTION
## Summary
- 將主畫面 AppBar 標題顏色改為橘色
- 將側邊欄 Drawer 中的應用程式標題顏色改為橘色
- 將新增/編輯待辦事項畫面的 AppBar 標題顏色改為橘色

Closes #2

🤖 Generated with [Claude Code](https://claude.ai/code)